### PR TITLE
Recreate submodule binding for _includes/Header

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "Header"]
+[submodule "_includes/Header"]
 	path = _includes/Header
-  url = https://github.com/AgoraNomic/Header.git
+	url = https://github.com/AgoraNomic/Header


### PR DESCRIPTION
```
$ rm .gitmodules

$ git submodule add https://github.com/AgoraNomic/Header _includes/Header
Cloning into '/Users/owen/Development/grimoire.ca/ADoP/_includes/Header'...
remote: Counting objects: 23, done.
remote: Total 23 (delta 0), reused 0 (delta 0), pack-reused 23
Unpacking objects: 100% (23/23), done.

$ cat .gitmodules
[submodule "_includes/Header"]
	path = _includes/Header
	url = https://github.com/AgoraNomic/Header

$ git add _includes/Header

$ git commit -m 'Recreate submodule binding for _includes/Header'

You need a passphrase to unlock the secret key for
user: "Owen Jacobson <owen@grimoire.ca>"
2048-bit RSA key, ID 50232991F10DFFD0, created 2014-06-09

[master 58be647] Recreate submodule binding for _includes/Header
 2 files changed, 3 insertions(+), 2 deletions(-)
 create mode 160000 _includes/Header

$ git push ojacobson master:add-header
Counting objects: 4, done.
Delta compression using up to 4 threads.
Compressing objects: 100% (3/3), done.
Writing objects: 100% (4/4), 927 bytes | 927.00 KiB/s, done.
Total 4 (delta 0), reused 0 (delta 0)
hub pull-request To github.com:ojacobson/ADoP.git
 * [new branch]      master -> add-header
```